### PR TITLE
Fixed the the calling of postFrameCallback method

### DIFF
--- a/lib/measure_size.dart
+++ b/lib/measure_size.dart
@@ -26,8 +26,13 @@ class _MeasureSizeState extends State<MeasureSize> {
   Size? oldSize;
 
   @override
-  Widget build(BuildContext context) {
+  void initState() {
+    super.initState();
     SchedulerBinding.instance.addPostFrameCallback(postFrameCallback);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
       key: widgetKey,
       child: widget.child,


### PR DESCRIPTION
- make sure the method is calling once for each build by putting it inside the `initState()`.
- From the original code, from my testing, the `onChange` will return inconsistent Size value for each hot-reload.